### PR TITLE
#37 Change default branch from 'main' to 'master' in qodana workflow

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches: # Specify your branches here
-      - main # The 'main' branch
+      - master # The 'main' branch
       - "releases/*" # The release branches
 
 jobs:


### PR DESCRIPTION
## Fixes #37 
Since we use `master` as our main branch, we need to have that reflected in our qodana workflow config.